### PR TITLE
fix bug with linear scale

### DIFF
--- a/colorlegend.js
+++ b/colorlegend.js
@@ -58,7 +58,7 @@ var colorlegend = function (target, scale, type, options) {
     var min = domain[0];
     var max = domain[domain.length - 1];
     for (i = 0; i < linearBoxes ; i++) {
-      colors[i] = scale(i * ((max - min) / linearBoxes));
+      colors[i] = scale(min + i * ((max - min) / linearBoxes));
     }
   }
   


### PR DESCRIPTION
previously it was assumed the domain started at 0, but the domain should actually start at min.
